### PR TITLE
Remove workaround for missing api_host from SwitchProfile.

### DIFF
--- a/src/pennsieve2/userProfile.py
+++ b/src/pennsieve2/userProfile.py
@@ -72,6 +72,6 @@ class UserProfile:
         self.current_user = self._stub.SwitchProfile(request=request)
         logger.debug(f"current_user switched to: {self.current_user}")
         # Versions of the Agent prior to 1.3.1 did not populate the api_host field in SwitchProfile responses.
-        if self.current_user.api_host == '':
-            logger.warning(f'Base API URL missing from SwitchProfile response. Update Agent to version >= 1.3.2')
+        if self.current_user.api_host == "":
+            logger.warning(f"Base API URL missing from SwitchProfile response. Update Agent to version >= 1.3.2")
         logger.info(f"Switched profile to: {self.current_user.profile}")


### PR DESCRIPTION
The Pennsieve agent has been updated to return the api host names in SwitchProfile response. This PR removes the workaround we had in place to deal with the missing fields. 

If user is running an older version of the agent with the missing fields they will see a warning message suggesting an upgrade of agent when they call `Pennsieve.switch()`. Post-switch, calls to http methods that use short URLs, e.g., `get(/datasets)`, will fail unless the user upgrades.