### PR TITLE
Fix: AttributeError: 'Pennsieve' object has no attribute 'datasets'. …

### DIFF
--- a/src/pennsieve/pennsieve.py
+++ b/src/pennsieve/pennsieve.py
@@ -241,7 +241,7 @@ the 'connect=false' parameter.
         self.get_datasets()
         if self._datasets and dataset_id in self._datasets.keys():
             self.dataset = self._datasets[dataset_id]
-        elif dataset_id in self._datasets.values():
+        elif self._datasets and dataset_id in self._datasets.values():
             self.dataset = dataset_id
         assert self.dataset is not None
         request = agent_pb2.UseDatasetRequest(dataset_id=self.dataset)


### PR DESCRIPTION
…Upon investigating this bug I found that the user was using an older version of pennsieve python client causing the end user to recieve the error. This was fixed in pennsieve2 v0.1.2 and is not present in the current version. While searching for this bug I encountered another case when a user has zero datasets, get_datasets() returns None for self._datasets. The case was present in the if block but not the elif portion, causing None.values() to throw a seperate AttributeError. To fix I added the same logic to the elif block.